### PR TITLE
Move variants configuration to `userVariants` section.

### DIFF
--- a/src/Winp/Configuration/MariaDbConfig.cs
+++ b/src/Winp/Configuration/MariaDbConfig.cs
@@ -16,14 +16,7 @@ public record MariaDbConfig
         ("3978118", "11.7.1", true)
     };
 
-    [JsonProperty(PropertyName = "dataDirectory")]
-    public string DataDirectory = "data";
-
-    [JsonProperty(PropertyName = "serverPort")]
-    public int ServerPort = 3306;
-
-    [JsonProperty(PropertyName = "variants")]
-    public IReadOnlyList<PackageVariantConfig> Variants = MariaDbVariants
+    private static readonly IReadOnlyList<PackageVariantConfig> DefaultVariants = MariaDbVariants
         .Select(variant => new PackageVariantConfig
         {
             DownloadUrl = new Uri(
@@ -33,4 +26,16 @@ public record MariaDbConfig
             PathInArchive = $"mariadb-{variant.Version}-{Platform}"
         })
         .ToArray();
+
+    [JsonProperty(PropertyName = "dataDirectory")]
+    public string DataDirectory = "data";
+
+    [JsonProperty(PropertyName = "serverPort")]
+    public int ServerPort = 3306;
+
+    [JsonProperty(PropertyName = "userVariants")]
+    public IReadOnlyList<PackageVariantConfig> UserVariants = [];
+
+    [JsonIgnore]
+    public IReadOnlyList<PackageVariantConfig> Variants => UserVariants.Count > 0 ? UserVariants : DefaultVariants;
 }

--- a/src/Winp/Configuration/NginxConfig.cs
+++ b/src/Winp/Configuration/NginxConfig.cs
@@ -14,14 +14,7 @@ public record NginxConfig
         ("1.27.1", true)
     };
 
-    [JsonProperty(PropertyName = "serverAddress")]
-    public string ServerAddress = "127.0.0.1";
-
-    [JsonProperty(PropertyName = "serverPort")]
-    public int ServerPort = 80;
-
-    [JsonProperty(PropertyName = "variants")]
-    public IReadOnlyList<PackageVariantConfig> Variants = NginxVariants
+    private static readonly IReadOnlyList<PackageVariantConfig> DefaultVariants = NginxVariants
         .Select(variant => new PackageVariantConfig
         {
             DownloadUrl = new Uri($"{DownloadBase}/nginx-{variant.Version}.zip"),
@@ -30,4 +23,16 @@ public record NginxConfig
             PathInArchive = $"nginx-{variant.Version}"
         })
         .ToArray();
+
+    [JsonProperty(PropertyName = "serverAddress")]
+    public string ServerAddress = "127.0.0.1";
+
+    [JsonProperty(PropertyName = "serverPort")]
+    public int ServerPort = 80;
+
+    [JsonProperty(PropertyName = "userVariants")]
+    public IReadOnlyList<PackageVariantConfig> UserVariants = [];
+
+    [JsonIgnore]
+    public IReadOnlyList<PackageVariantConfig> Variants => UserVariants.Count > 0 ? UserVariants : DefaultVariants;
 }

--- a/src/Winp/Configuration/PhpConfig.cs
+++ b/src/Winp/Configuration/PhpConfig.cs
@@ -17,6 +17,15 @@ public record PhpConfig
         ("8.3.9", true)
     };
 
+    private static readonly IReadOnlyList<PackageVariantConfig> DefaultVariants = PhpVariants
+        .Select(variant => new PackageVariantConfig
+        {
+            DownloadUrl = new Uri($"{DownloadBase}/php-{variant.Version}-{Platform}.zip"),
+            Identifier = $"{variant.Version}-{Platform}",
+            IsSelected = variant.IsLatest
+        })
+        .ToArray();
+
     [JsonProperty(PropertyName = "extensions")]
     public IReadOnlyList<string> Extensions = new[]
     {
@@ -37,13 +46,9 @@ public record PhpConfig
     [JsonProperty(PropertyName = "serverPort")]
     public int ServerPort = 9000;
 
-    [JsonProperty(PropertyName = "variants")]
-    public IReadOnlyList<PackageVariantConfig> Variants = PhpVariants
-        .Select(variant => new PackageVariantConfig
-        {
-            DownloadUrl = new Uri($"{DownloadBase}/php-{variant.Version}-{Platform}.zip"),
-            Identifier = $"{variant.Version}-{Platform}",
-            IsSelected = variant.IsLatest
-        })
-        .ToArray();
+    [JsonProperty(PropertyName = "userVariants")]
+    public IReadOnlyList<PackageVariantConfig> UserVariants = [];
+
+    [JsonIgnore]
+    public IReadOnlyList<PackageVariantConfig> Variants => UserVariants.Count > 0 ? UserVariants : DefaultVariants;
 }

--- a/src/Winp/Configuration/PhpMyAdminConfig.cs
+++ b/src/Winp/Configuration/PhpMyAdminConfig.cs
@@ -15,8 +15,7 @@ public record PhpMyAdminConfig
         ("5.2.1", true)
     };
 
-    [JsonProperty(PropertyName = "variants")]
-    public IReadOnlyList<PackageVariantConfig> Variants = PhpMyAdminVariants
+    private static readonly IReadOnlyList<PackageVariantConfig> DefaultVariants = PhpMyAdminVariants
         .Select(variant => new PackageVariantConfig
         {
             DownloadUrl = new Uri($"{DownloadBase}/{variant.Version}/phpMyAdmin-{variant.Version}-{Language}.zip"),
@@ -25,4 +24,10 @@ public record PhpMyAdminConfig
             PathInArchive = $"phpMyAdmin-{variant.Version}-{Language}"
         })
         .ToArray();
+
+    [JsonProperty(PropertyName = "userVariants")]
+    public IReadOnlyList<PackageVariantConfig> UserVariants = [];
+
+    [JsonIgnore]
+    public IReadOnlyList<PackageVariantConfig> Variants => UserVariants.Count > 0 ? UserVariants : DefaultVariants;
 }


### PR DESCRIPTION
Stop writing default variants to configuration and only take user-defined overrides into account. This will avoid obsolete versions in configuration files when users never set them manually in the first place.